### PR TITLE
BREAKING: Autogenerated message <-> configuration conversions

### DIFF
--- a/src/message.zig
+++ b/src/message.zig
@@ -99,76 +99,75 @@ pub const Message = packed struct {
             /// index must be provided.
             pub fn fromConfig(self: *@This(), config: Config) void {
                 switch (self.kind) {
-                    .id => self.value.u16 = config.id.driver,
-                    .station => self.value.u16 = config.id.station,
+                    .id => self.value.u16 = config.id,
+                    .station => self.value.u16 = config.station,
                     .flags => self.value.u16 =
                         @as(u10, @bitCast(config.flags)),
                     .@"magnet.pitch" => self.value.f32 = config.magnet.pitch,
                     .@"magnet.length" => self.value.f32 =
                         config.magnet.length,
-                    .@"carrier.mass" => self.value.f32 = config.vehicle_mass,
+                    .@"carrier.mass" => self.value.f32 = config.carrier.mass,
                     .@"carrier.arrival.threshold.position" => self.value.f32 =
-                        config.arrival.threshold.position,
+                        config.carrier.arrival.threshold.position,
                     .@"carrier.arrival.threshold.velocity" => self.value.f32 =
-                        config.arrival.threshold.velocity,
+                        config.carrier.arrival.threshold.velocity,
                     .mechanical_angle_offset => self.value.f32 =
                         config.mechanical_angle_offset,
-                    .@"axis.length" => self.value.f32 = config.axis_length,
-                    .@"coil.length" => self.value.f32 = config.motor.length,
+                    .@"axis.length" => self.value.f32 = config.axis.length,
+                    .@"coil.length" => self.value.f32 = config.coil.length,
                     .@"coil.max_current" => self.value.f32 =
-                        config.motor.max_current,
+                        config.coil.max_current,
                     .@"coil.continuous_current" => self.value.f32 =
-                        config.motor.continuous_current,
-                    .@"coil.rs" => self.value.f32 = config.motor.rs,
-                    .@"coil.ls" => self.value.f32 = config.motor.ls,
-                    .@"coil.kf" => self.value.f32 = config.motor.kf,
-                    .@"coil.kbm" => self.value.f32 = config.motor.kbm,
-                    .zero_position => self.value.f32 =
-                        config.calibrated_home_position,
-                    .line_axes => self.value.u32 = config.total_axes,
+                        config.coil.continuous_current,
+                    .@"coil.rs" => self.value.f32 = config.coil.rs,
+                    .@"coil.ls" => self.value.f32 = config.coil.ls,
+                    .@"coil.kf" => self.value.f32 = config.coil.kf,
+                    .@"coil.kbm" => self.value.f32 = config.coil.kbm,
+                    .zero_position => self.value.f32 = config.zero_position,
+                    .line_axes => self.value.u32 = config.line_axes,
                     .warmup_voltage => self.value.f32 =
-                        config.warmup_voltage_reference,
+                        config.warmup_voltage,
                     .@"default_magnet_length.backward" => self.value.f32 =
-                        config.calibration_magnet_length.backward,
+                        config.default_magnet_length.backward,
                     .@"default_magnet_length.forward" => self.value.f32 =
-                        config.calibration_magnet_length.forward,
+                        config.default_magnet_length.forward,
                     .@"vdc.target" => self.value.f32 = config.vdc.target,
                     .@"vdc.limit.lower" => self.value.f32 =
                         config.vdc.limit.lower,
                     .@"vdc.limit.upper" => self.value.f32 =
                         config.vdc.limit.upper,
                     .@"axes.gain.current.p" => self.value.f32 =
-                        config.axes[self.index].current_gain.p,
+                        config.axes[self.index].gain.current.p,
                     .@"axes.gain.current.i" => self.value.f32 =
-                        config.axes[self.index].current_gain.i,
+                        config.axes[self.index].gain.current.i,
                     .@"axes.gain.current.denominator" => self.value.u32 =
-                        config.axes[self.index].current_gain.denominator,
+                        config.axes[self.index].gain.current.denominator,
                     .@"axes.gain.velocity.p" => self.value.f32 =
-                        config.axes[self.index].velocity_gain.p,
+                        config.axes[self.index].gain.velocity.p,
                     .@"axes.gain.velocity.i" => self.value.f32 =
-                        config.axes[self.index].velocity_gain.i,
+                        config.axes[self.index].gain.velocity.i,
                     .@"axes.gain.velocity.denominator" => self.value.u32 =
-                        config.axes[self.index].velocity_gain.denominator,
+                        config.axes[self.index].gain.velocity.denominator,
                     .@"axes.gain.velocity.denominator_pi" => self.value.u32 =
-                        config.axes[self.index].velocity_gain.denominator_pi,
+                        config.axes[self.index].gain.velocity.denominator_pi,
                     .@"axes.gain.position.p" => self.value.f32 =
-                        config.axes[self.index].position_gain.p,
+                        config.axes[self.index].gain.position.p,
                     .@"axes.gain.position.denominator" => self.value.u32 =
-                        config.axes[self.index].position_gain.denominator,
+                        config.axes[self.index].gain.position.denominator,
                     .@"axes.base_position" => self.value.f32 =
                         config.axes[self.index].base_position,
                     .@"axes.sensor_off.back.position" => self.value.i16 =
-                        config.axes[self.index].back_sensor_off.position,
+                        config.axes[self.index].sensor_off.back.position,
                     .@"axes.sensor_off.back.section_count" => self.value.i16 =
-                        config.axes[self.index].back_sensor_off.section_count,
+                        config.axes[self.index].sensor_off.back.section_count,
                     .@"axes.sensor_off.front.position" => self.value.i16 =
-                        config.axes[self.index].front_sensor_off.position,
+                        config.axes[self.index].sensor_off.front.position,
                     .@"axes.sensor_off.front.section_count" => self.value.i16 =
-                        config.axes[self.index].front_sensor_off.section_count,
+                        config.axes[self.index].sensor_off.front.section_count,
                     .@"hall_sensors.magnet_length.backward" => self.value.f32 =
-                        config.hall_sensors[self.index].calibrated_magnet_length.backward,
+                        config.hall_sensors[self.index].magnet_length.backward,
                     .@"hall_sensors.magnet_length.forward" => self.value.f32 =
-                        config.hall_sensors[self.index].calibrated_magnet_length.forward,
+                        config.hall_sensors[self.index].magnet_length.forward,
                     .@"hall_sensors.ignore_distance.backward" => self.value.f32 =
                         config.hall_sensors[self.index].ignore_distance.backward,
                     .@"hall_sensors.ignore_distance.forward" => self.value.f32 =
@@ -182,10 +181,7 @@ pub const Message = packed struct {
                     .value = undefined,
                 } };
                 const conf: Config = std.mem.zeroInit(Config, .{
-                    .id = .{
-                        .driver = 1,
-                        .station = 13,
-                    },
+                    .station = 13,
                 });
                 pl.config_set.fromConfig(conf);
                 try std.testing.expectEqual(13, pl.config_set.value.u16);
@@ -194,8 +190,8 @@ pub const Message = packed struct {
             /// Set the corresponding Config struct value from this message.
             pub fn setConfig(self: @This(), config: *Config) void {
                 switch (self.kind) {
-                    .id => config.id.driver = self.value.u16,
-                    .station => config.id.station = self.value.u16,
+                    .id => config.id = self.value.u16,
+                    .station => config.station = self.value.u16,
                     .flags => config.flags = @bitCast(@as(
                         @typeInfo(Config.Flags).@"struct".backing_integer.?,
                         @truncate(self.value.u16),
@@ -204,41 +200,41 @@ pub const Message = packed struct {
                     .@"magnet.length" => {
                         config.magnet.length = self.value.f32;
                     },
-                    .@"carrier.mass" => config.vehicle_mass = self.value.f32,
+                    .@"carrier.mass" => config.carrier.mass = self.value.f32,
                     .@"carrier.arrival.threshold.position" => {
-                        config.arrival.threshold.position = self.value.f32;
+                        config.carrier.arrival.threshold.position = self.value.f32;
                     },
                     .@"carrier.arrival.threshold.velocity" => {
-                        config.arrival.threshold.velocity = self.value.f32;
+                        config.carrier.arrival.threshold.velocity = self.value.f32;
                     },
                     .mechanical_angle_offset => {
                         config.mechanical_angle_offset = self.value.f32;
                     },
-                    .@"axis.length" => config.axis_length = self.value.f32,
-                    .@"coil.length" => config.motor.length = self.value.f32,
+                    .@"axis.length" => config.axis.length = self.value.f32,
+                    .@"coil.length" => config.coil.length = self.value.f32,
                     .@"coil.max_current" => {
-                        config.motor.max_current = self.value.f32;
+                        config.coil.max_current = self.value.f32;
                     },
                     .@"coil.continuous_current" => {
-                        config.motor.continuous_current = self.value.f32;
+                        config.coil.continuous_current = self.value.f32;
                     },
-                    .@"coil.rs" => config.motor.rs = self.value.f32,
-                    .@"coil.ls" => config.motor.ls = self.value.f32,
-                    .@"coil.kf" => config.motor.kf = self.value.f32,
-                    .@"coil.kbm" => config.motor.kbm = self.value.f32,
+                    .@"coil.rs" => config.coil.rs = self.value.f32,
+                    .@"coil.ls" => config.coil.ls = self.value.f32,
+                    .@"coil.kf" => config.coil.kf = self.value.f32,
+                    .@"coil.kbm" => config.coil.kbm = self.value.f32,
                     .zero_position => {
-                        config.calibrated_home_position = self.value.f32;
+                        config.zero_position = self.value.f32;
                     },
-                    .line_axes => config.total_axes = self.value.u32,
+                    .line_axes => config.line_axes = self.value.u32,
                     .warmup_voltage => {
-                        config.warmup_voltage_reference = self.value.f32;
+                        config.warmup_voltage = self.value.f32;
                     },
                     .@"default_magnet_length.backward" => {
-                        config.calibration_magnet_length.backward =
+                        config.default_magnet_length.backward =
                             self.value.f32;
                     },
                     .@"default_magnet_length.forward" => {
-                        config.calibration_magnet_length.forward =
+                        config.default_magnet_length.forward =
                             self.value.f32;
                     },
                     .@"vdc.target" => {
@@ -251,39 +247,39 @@ pub const Message = packed struct {
                         config.vdc.limit.upper = self.value.f32;
                     },
                     .@"axes.gain.current.p" => {
-                        config.axes[self.index].current_gain.p =
+                        config.axes[self.index].gain.current.p =
                             self.value.f32;
                     },
                     .@"axes.gain.current.i" => {
-                        config.axes[self.index].current_gain.i =
+                        config.axes[self.index].gain.current.i =
                             self.value.f32;
                     },
                     .@"axes.gain.current.denominator" => {
-                        config.axes[self.index].current_gain.denominator =
+                        config.axes[self.index].gain.current.denominator =
                             self.value.u32;
                     },
                     .@"axes.gain.velocity.p" => {
-                        config.axes[self.index].velocity_gain.p =
+                        config.axes[self.index].gain.velocity.p =
                             self.value.f32;
                     },
                     .@"axes.gain.velocity.i" => {
-                        config.axes[self.index].velocity_gain.i =
+                        config.axes[self.index].gain.velocity.i =
                             self.value.f32;
                     },
                     .@"axes.gain.velocity.denominator" => {
-                        config.axes[self.index].velocity_gain.denominator =
+                        config.axes[self.index].gain.velocity.denominator =
                             self.value.u32;
                     },
                     .@"axes.gain.velocity.denominator_pi" => {
-                        config.axes[self.index].velocity_gain.denominator_pi =
+                        config.axes[self.index].gain.velocity.denominator_pi =
                             self.value.u32;
                     },
                     .@"axes.gain.position.p" => {
-                        config.axes[self.index].position_gain.p =
+                        config.axes[self.index].gain.position.p =
                             self.value.f32;
                     },
                     .@"axes.gain.position.denominator" => {
-                        config.axes[self.index].position_gain.denominator =
+                        config.axes[self.index].gain.position.denominator =
                             self.value.u32;
                     },
                     .@"axes.base_position" => {
@@ -291,27 +287,27 @@ pub const Message = packed struct {
                             self.value.f32;
                     },
                     .@"axes.sensor_off.back.position" => {
-                        config.axes[self.index].back_sensor_off.position =
+                        config.axes[self.index].sensor_off.back.position =
                             self.value.i16;
                     },
                     .@"axes.sensor_off.back.section_count" => {
-                        config.axes[self.index].back_sensor_off.section_count =
+                        config.axes[self.index].sensor_off.back.section_count =
                             self.value.i16;
                     },
                     .@"axes.sensor_off.front.position" => {
-                        config.axes[self.index].front_sensor_off.position =
+                        config.axes[self.index].sensor_off.front.position =
                             self.value.i16;
                     },
                     .@"axes.sensor_off.front.section_count" => {
-                        config.axes[self.index].front_sensor_off.section_count =
+                        config.axes[self.index].sensor_off.front.section_count =
                             self.value.i16;
                     },
                     .@"hall_sensors.magnet_length.backward" => {
-                        config.hall_sensors[self.index].calibrated_magnet_length.backward =
+                        config.hall_sensors[self.index].magnet_length.backward =
                             self.value.f32;
                     },
                     .@"hall_sensors.magnet_length.forward" => {
-                        config.hall_sensors[self.index].calibrated_magnet_length.forward =
+                        config.hall_sensors[self.index].magnet_length.forward =
                             self.value.f32;
                     },
                     .@"hall_sensors.ignore_distance.backward" => {
@@ -331,7 +327,7 @@ pub const Message = packed struct {
                     .kind = .station,
                     .value = .{ .u16 = 3 },
                 }, &config);
-                try std.testing.expectEqual(3, config.id.station);
+                try std.testing.expectEqual(3, config.station);
             }
         };
     };

--- a/src/message.zig
+++ b/src/message.zig
@@ -86,7 +86,7 @@ pub const Message = packed struct {
         u8: [8]u8,
 
         pub const ConfigField = extern struct {
-            kind: Config.FieldKind,
+            kind: Config.Field.Kind,
             index: u16 = 0,
             value: extern union {
                 i16: i16,


### PR DESCRIPTION
`Message` and `Config` can now convert between each other using `comptime` generated functions in `Message` and `Config.Field`, making updates and maintenance easier. This also breaks the existing configuration file format to better match the messages and driver configuration.